### PR TITLE
Add database design to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Things you may want to cover:
 
 * Deployment instructions
 
-* Database design
+# Database design
 ## users table
 |Column|Type|Options|
 |------|----|-------|

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Things you may want to cover:
 |name|string|null: false|
 ### Association
 - has_many :users, through: :groups_users
+- has_many :groups_users
 - has_many :messages
 
 ## groups_users table

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Things you may want to cover:
 ### Association
 - has_many :messages
 - has_many :groups, through: :groups_users
+- has_many :groups_users
 
 ## groups table
 |Column|Type|Options|

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Things you may want to cover:
 |------|----|-------|
 |email|string|null: false|
 |password|string|null: false|
-|username|string|null: false|
+|name|string|null: false|
 ### Association
 - has_many :massages
 - has_many :groups, through: :groups_users

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Things you may want to cover:
 ## groups table
 |Column|Type|Options|
 |------|----|-------|
-|group_name|string|null: false|
+|name|string|null: false|
 ### Association
 - has_many :users, through: :groups_users
 - has_many :messages

--- a/README.md
+++ b/README.md
@@ -21,4 +21,43 @@ Things you may want to cover:
 
 * Deployment instructions
 
+* Database design
+## users table
+|Column|Type|Options|
+|------|----|-------|
+|email|string|null: false|
+|password|string|null: false|
+|username|string|null: false|
+### Association
+- has_many :massages
+- has_many :groups, through: :groups_users
+
+## groups table
+|Column|Type|Options|
+|------|----|-------|
+|group_name|string|null: false|
+### Association
+- has_many :users, through: :groups_users
+- has_many :messages
+
+## groups_users table
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+### Association
+- belongs_to :group
+- belongs_to :user
+
+## messages table
+|Column|Type|Options|
+|------|----|-------|
+|body|text|null: false|
+|image|string||
+|use_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+### Association
+- belongs_to :user
+- belongs_to :group
+
 * ...

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Things you may want to cover:
 ## messages table
 |Column|Type|Options|
 |------|----|-------|
-|body|text|null: false|
+|body|text||
 |image|string||
 |use_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Things you may want to cover:
 |password|string|null: false|
 |name|string|null: false|
 ### Association
-- has_many :massages
+- has_many :messages
 - has_many :groups, through: :groups_users
 
 ## groups table


### PR DESCRIPTION
# What
ChatSpaceのデータベース設計を行った。必要と考えられる以下のテーブルについて、カラム、データ型、オプション、アソシエーションをREADME.mdに記述した。
- **users** : ユーザー情報の管理用
- **groups** : グループ情報の管理用
- **groups_users** : usersテーブルとgroupsテーブル間の中間テーブル
- **messages** : チャットメッセージと投稿画像の管理用

# Why
アプリケーションの根幹であるため。