### PR TITLE
グループ編集機能ページ遷移の追加

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -95,6 +95,8 @@ body::-webkit-scrollbar {
     }
     &__btn {
       @include button($edit_btn_height);
+      text-decoration: none;
+      line-height: $edit_btn_height;
       margin-top: ($header_height - $edit_btn_height)/2;
     }
   }

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -24,7 +24,7 @@ class GroupsController < ApplicationController
 
   def update
     if @group.update(group_params)
-      redirect_to root_path, notice: 'グループを更新しました'
+      redirect_to group_messages_path(@group), notice: 'グループを更新しました'
     else
       render :edit
     end


### PR DESCRIPTION
# What
- ヘッダーのEditボタンからグループ編集画面にリンクするようにした。
- 編集後、そのグループのメーっセージ一覧画面にリダイレクトするように変更した。
- Editボタンの見た目を調整した。
# Why
- ヘッダーからグループ編集画面に移動できるようになる