### PR TITLE
自動更新機能の実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -77,11 +77,13 @@ $(function(){
         insertHTML += buildHTML(message);
       });
       $('.main_message').append(insertHTML)
-      console.log("success");
+      $('.main_message').animate({ scrollTop: $('.main_message')[0].scrollHeight});
     })
     .fail(function(){
-      console.log("error");
+      alert("自動更新に失敗しました");
     })
   };
-  setInterval(reloadMessages, 7000);
+  if ($(".main_message").length){
+    setInterval(reloadMessages, 7000);
+  }
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -61,7 +61,7 @@ $(function(){
     })
   });
   var reloadMessages = function(){
-    var message_ids = $('div.main_message__list').map(function(){
+    var message_ids = $('.main_message__list').map(function(){
       return $(this).data('message-id');
     });
     var last_message_id = Math.max.apply(null, message_ids);

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -74,12 +74,14 @@ $(function(){
     .done(function(messages){
       var insertHTML ='';
       $.each(messages, function(i, message){
-        insertHTML += buildeHTML(message);
+        insertHTML += buildHTML(message);
       });
       $('.main_message').append(insertHTML)
+      console.log("success");
     })
     .fail(function(){
       console.log("error");
     })
   };
+  setInterval(reloadMessages, 7000);
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -32,7 +32,7 @@ $(function(){
                     <div class="main_message__message_body"></div>
                     ${message.body}
                     ${image_html}
-                    </div>
+                  </div>
                 </div>`;
     return html
   }
@@ -60,4 +60,22 @@ $(function(){
       $('.main_form__btn').prop('disabled', false);
     })
   });
+  var reloadMessages = function(){
+    var message_ids = $('div.main_message__list').map(function(){
+      return $(this).data('message-id');
+    });
+    var last_message_id = Math.max.apply(null, message_ids);
+    $.ajax({
+      url: "api/messages",
+      type: "GET",
+      dataType: 'json',
+      data: {id: last_message_id}
+    })
+    .done(function(messages){
+      console.log("success");
+    })
+    .fail(function(){
+      console.log("error");
+    })
+  };
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -19,7 +19,7 @@ $(function(){
     if (message.image.url){
       image_html = `<image class="main_message__message_image" src="${message.image.url}"></image>`;
     }
-    var html =  `<div class="main_message__list">
+    var html =  `<div class="main_message__list" data-message-id="${message.id}">
                   <div class="main_message__header">
                     <div class="main_message__header_user">
                     ${message.user_name}

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -61,10 +61,7 @@ $(function(){
     })
   });
   var reloadMessages = function(){
-    var message_ids = $('.main_message__list').map(function(){
-      return $(this).data('message-id');
-    });
-    var last_message_id = Math.max.apply(null, message_ids);
+    var last_message_id = $('.main_message__list:last').data('message-id');
     $.ajax({
       url: "api/messages",
       type: "GET",

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -72,7 +72,11 @@ $(function(){
       data: {id: last_message_id}
     })
     .done(function(messages){
-      console.log("success");
+      var insertHTML ='';
+      $.each(messages, function(i, message){
+        insertHTML += buildeHTML(message);
+      });
+      $('.main_message').append(insertHTML)
     })
     .fail(function(){
       console.log("error");

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,7 @@
+class Api::MessagesController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = group.messages.includes(:user).where("id > #{last_message_id}")
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.body message.body
+  json.image message.image
+  json.created_at message.created_at
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.main_message__list
+.main_message__list{data: {message: {id: "#{message.id}"}}}
   .main_message__header
     .main_message__header_user
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,4 @@ json.body @message.body
 json.image @message.image
 json.user_name @message.user.name
 json.created_at @message.created_at
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,8 @@ Rails.application.routes.draw do
   resources :users, only: [:edit, :update, :destroy, :index]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
# What
- メッセージのHTMLにカスタムデータ属性としてメッセージIDを追加した。
- 表示されているメッセージIDの最大値を取得し、DBとの差分だけを追加するようにした。
- メッセージ一覧画面のみで7秒ごとに自動更新処理を実行するようにした。
# Why
カレントユーザー以外が投稿した場合にも投稿が画面に反映されるようになる。