### PR TITLE
グループ編集画面のエラー表示の修正

### DIFF
--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -1,9 +1,10 @@
 = form_for group do |f|
-  .chat-group-form__errors
-    %h2= "#{@group.errors.full_messages.count}件のエラーが発生しました。"
-    %ul
-      - @group.errors.full_messages.each do |message|
-        %li= message
+  - if group.errors.any?
+    .chat-group-form__errors
+      %h2= "#{@group.errors.full_messages.count}件のエラーが発生しました。"
+      %ul
+        - @group.errors.full_messages.each do |message|
+          %li= message
   .chat-group-form__field
     .chat-group-form__field--left
       = f.label :name, class: 'chat-group-form__label'


### PR DESCRIPTION
# What
 エラー表示について、エラーの有無で表示の有無を切り替えるように条件式を追加した。
# Why
 不要であったエラーがない時のエラー表示を廃止できる。